### PR TITLE
Fix parsing errors and add support for additional node types

### DIFF
--- a/XbfAnalyzer/MainWindow.xaml.cs
+++ b/XbfAnalyzer/MainWindow.xaml.cs
@@ -122,40 +122,50 @@ namespace XbfAnalyzer
                     LogHexAddressMessage(i, xbf.XmlNamespaceTable[i]);
                 LogMessage();
 
+                // Node section table
+                LogLine();
+                LogMessage("Node section table:");
+                for (int i = 0; i < xbf.NodeSectionTable.Length; i++)
+                    LogHexAddressMessage(i, "Node offset: {0} (0x{0:X}) Positional offset: {1} (0x{1:X})", xbf.NodeSectionTable[i].NodeOffset, xbf.NodeSectionTable[i].PositionalOffset);
+                LogMessage();
+
                 // Nodes
                 LogLine();
                 if (xbf.Header.MajorFileVersion < 2)
-                {
                     LogMessage("Parsing XBF v1 nodes is not currently supported.");
-                }
                 else
                 {
-                    LogMessage("XAML objects:");
-                    if (!string.IsNullOrEmpty(xbf.NodeParserError))
-                    {
-                        LogMessage(xbf.NodeParserError);
-                        LogMessage();
-                        LogMessage("Partial node results:");
-                    }
-                    LogMessage(xbf.NodeResultString);
+                    string xaml = xbf.RootObject.ToString();
+                    LogMessage("XAML objects:");              
+                    LogMessage(xaml);
                 }
             }
             catch (Exception ex)
             {
                 LogMessage("Error: " + ex.ToString());
             }
+
+            ShowLog();
         }
 
         #region Message Logging
 
+        private StringBuilder log = new StringBuilder();
+
+        private void ShowLog()
+        {
+            OutputTextBox.Text = log.ToString();
+        }
+
         private void ClearLog()
         {
+            log.Clear();
             OutputTextBox.Text = null;
         }
 
         private void LogMessage(string message = "")
         {
-            OutputTextBox.Text += message + Environment.NewLine;
+            log.AppendLine(message);
         }
 
         private void LogMessage(string format, params object[] args)

--- a/XbfAnalyzer/MainWindow.xaml.cs
+++ b/XbfAnalyzer/MainWindow.xaml.cs
@@ -122,21 +122,21 @@ namespace XbfAnalyzer
                     LogHexAddressMessage(i, xbf.XmlNamespaceTable[i]);
                 LogMessage();
 
-                // Node section table
-                LogLine();
-                LogMessage("Node section table:");
-                for (int i = 0; i < xbf.NodeSectionTable.Length; i++)
-                    LogHexAddressMessage(i, "Node offset: {0} (0x{0:X}) Positional offset: {1} (0x{1:X})", xbf.NodeSectionTable[i].NodeOffset, xbf.NodeSectionTable[i].PositionalOffset);
-                LogMessage();
-
-                // Nodes
-                LogLine();
                 if (xbf.Header.MajorFileVersion < 2)
                     LogMessage("Parsing XBF v1 nodes is not currently supported.");
                 else
                 {
+                    // Node section table
+                    LogLine();                
+                    LogMessage("Node section table:");
+                    for (int i = 0; i < xbf.NodeSectionTable.Length; i++)
+                        LogHexAddressMessage(i, "Node offset: {0} (0x{0:X}) Positional offset: {1} (0x{1:X})", xbf.NodeSectionTable[i].NodeOffset, xbf.NodeSectionTable[i].PositionalOffset);
+                    LogMessage();
+
+                    // Nodes
+                    LogLine();
                     string xaml = xbf.RootObject.ToString();
-                    LogMessage("XAML objects:");              
+                    LogMessage("XAML objects:");
                     LogMessage(xaml);
                 }
             }

--- a/XbfAnalyzer/Xbf/XbfHeader.cs
+++ b/XbfAnalyzer/Xbf/XbfHeader.cs
@@ -14,7 +14,7 @@ namespace XbfAnalyzer.Xbf
             // Verify magic number
             var magicNumber = reader.ReadBytes(4);
             if (magicNumber[0] != 'X' || magicNumber[1] != 'B' || magicNumber[2] != 'F' || magicNumber[3] != 0)
-                throw new Exception("File does not have XBF header");
+                throw new InvalidDataException("File does not have XBF header");
             MagicNumber = magicNumber;
 
             MetadataSize = reader.ReadUInt32();

--- a/XbfAnalyzer/Xbf/XbfNodeSection.cs
+++ b/XbfAnalyzer/Xbf/XbfNodeSection.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XbfAnalyzer.Xbf
+{
+    public class XbfNodeSection
+    {
+        public XbfNodeSection(XbfReader xbf, BinaryReader reader)
+        {
+            NodeOffset = reader.ReadInt32();
+            PositionalOffset = reader.ReadInt32();
+        }
+
+        public int NodeOffset { get; private set; }
+        public int PositionalOffset { get; private set; }
+    }
+}

--- a/XbfAnalyzer/Xbf/XbfObject.cs
+++ b/XbfAnalyzer/Xbf/XbfObject.cs
@@ -14,8 +14,8 @@ namespace XbfAnalyzer.Xbf
         public string Key { get; set; }
         public int ConnectionID { get; set; }
 
-        private readonly List<XbfObjectProperty> _properties = new List<XbfObjectProperty>();
-        public List<XbfObjectProperty> Properties { get { return _properties; } }
+        public List<XbfObjectProperty> Properties { get; } = new List<XbfObjectProperty>();
+        public XbfObjectCollection Children { get; } = new XbfObjectCollection();
 
         public override string ToString()
         {
@@ -62,7 +62,7 @@ namespace XbfAnalyzer.Xbf
             }
 
             // If we don't have any complex properties or children, just close the object and return it
-            if (complexProperties.Length == 0)
+            if (complexProperties.Length == 0 && Children.Count == 0)
             {
                 sb.Append(" />");
                 return sb.ToString();
@@ -90,6 +90,10 @@ namespace XbfAnalyzer.Xbf
                 sb.AppendFormat(indent + _indent + "</{0}>", propertyName);
                 sb.AppendLine();
             }
+
+            // Children
+            foreach (var child in Children)
+                sb.AppendLine(child.ToString(indentLevel + 1));
 
             // Element closing
             sb.AppendFormat(indent + "</{0}>", TypeName);

--- a/XbfAnalyzer/Xbf/XbfReader.cs
+++ b/XbfAnalyzer/Xbf/XbfReader.cs
@@ -412,6 +412,17 @@ namespace XbfAnalyzer.Xbf
                             return; // The root object we just read is the single object we are supposed to read
                         break;
 
+                    case 0x18: // Looks to be equivalent to 0x17 but with an additional constructor argument
+                    case 0x19:
+                        {
+                            string typeName = GetTypeName(reader.ReadUInt16());
+                            object argument = GetPropertyValue(reader);
+                            // I am not aware of any way to specify constructor arguments in UWP XAML but XAML 2009 had an x:Arguments attribute for this, so let's use that instead
+                            _objectStack.Peek().Properties.Add(new XbfObjectProperty("x:Class", typeName));
+                            _objectStack.Peek().Properties.Add(new XbfObjectProperty("x:Arguments", argument));
+                        }
+                        break;
+
                     case 0x8B: // Unknown purpose, only encountered in one file
                         _objectStack.Pop();
                         break;

--- a/XbfAnalyzer/Xbf/XbfReader.cs
+++ b/XbfAnalyzer/Xbf/XbfReader.cs
@@ -36,27 +36,30 @@ namespace XbfAnalyzer.Xbf
                 TypeTable = ReadTable(reader, r => new XbfType(this, r));
                 PropertyTable = ReadTable(reader, r => new XbfProperty(this, r));
                 XmlNamespaceTable = ReadTable(reader, r => StringTable[r.ReadInt32()]);
-                NodeSectionTable = ReadTable(reader, r => new XbfNodeSection(this, reader));
-
-                // Each node section comes in two parts: the nodes themselves come first, followed by line/column data (positional data
-                // which indicates where the objects were located in the source XAML file).
-                // For each node section, there will be two offset numbers: one for the nodes, and one for the positional data.
-                //
-                // There seem to be a few situations that trigger a separate node section to be generated, including:
-                // - Visual state data (VisualStateGroups, VisualStates, etc.) seem to always generate a separate section.
-                //   Some visual state information is included in the primary node stream (after control character 0x0F) but fully-expanded
-                //   objects are only available in the secondary node streams (one per object that has VisualStateGroups defined).
-                // - Resource collections (i.e., groups of objects with x:Key values) seem generate a separate section when they have more than one item.
-                //   Different types of resources seem to generate multiple resource collections for the same object.
-                //   For example, Brush resources are listed separately from Style resources.
-                //
-                // Note that secondary node sections can also contain references to other node sections as well.
-
-                // We are now at the position in the stream of the first actual node data. We'll need this position later.
-                _firstNodeSectionPosition = (int)reader.BaseStream.Position;
 
                 if (Header.MajorFileVersion >= 2)
+                {
+                    // Each node section comes in two parts: the nodes themselves come first, followed by line/column data (positional data
+                    // which indicates where the objects were located in the source XAML file).
+                    // For each node section, there will be two offset numbers: one for the nodes, and one for the positional data.
+                    //
+                    // There seem to be a few situations that trigger a separate node section to be generated, including:
+                    // - Visual state data (VisualStateGroups, VisualStates, etc.) seem to always generate a separate section.
+                    //   Some visual state information is included in the primary node stream (after control character 0x0F) but fully-expanded
+                    //   objects are only available in the secondary node streams (one per object that has VisualStateGroups defined).
+                    // - Resource collections (i.e., groups of objects with x:Key values) seem generate a separate section when they have more than one item.
+                    //   Different types of resources seem to generate multiple resource collections for the same object.
+                    //   For example, Brush resources are listed separately from Style resources.
+                    //
+                    // Note that secondary node sections can also contain references to other node sections as well.
+
+                    // We are now at the position in the stream of the first actual node data. We'll need this position later.
+                    NodeSectionTable = ReadTable(reader, r => new XbfNodeSection(this, reader));
+
+                    _firstNodeSectionPosition = (int)reader.BaseStream.Position;
+
                     RootObject = ReadRootNodeSection(reader);
+                }
             }
         }
 

--- a/XbfAnalyzer/XbfAnalyzer.csproj
+++ b/XbfAnalyzer/XbfAnalyzer.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Xbf\XbfAssembly.cs" />
     <Compile Include="Xbf\XbfFrameworkTypes.cs" />
     <Compile Include="Xbf\XbfHeader.cs" />
+    <Compile Include="Xbf\XbfNodeSection.cs" />
     <Compile Include="Xbf\XbfObject.cs" />
     <Compile Include="Xbf\XbfObjectCollection.cs" />
     <Compile Include="Xbf\XbfObjectProperty.cs" />


### PR DESCRIPTION
- Added support for a number of additional node types
- Various fixes and extensions for DataTemplate, Style, ResourceDictionary and VisualStates
- Added a dedicated Children collection to XbfObject
- Added support for parsing nested root objects
- Added more checks for early detection of parsing errors
- Refactored some parts
- Sped up logging

These changes fix all parsing errors that I could find so that files can be read from start to end. There are still lots of places where the purpose of structures is unclear but they no longer crash the parser. XAML generation is still incomplete/incorrect in some places, especially with VisualStates, deferred elements and dependency properties but apart from that most files seem to get handled pretty well.
